### PR TITLE
Show registered date in the user profile information

### DIFF
--- a/user-access-expiration.php
+++ b/user-access-expiration.php
@@ -349,6 +349,10 @@ class UserAccessExpiration
 		<h3>User Access Expiration</h3>
 		<table class="form-table">
 		<tr>
+			<th>Registered date: </th>
+			<td><?php echo get_the_author_meta( 'user_registered', $user->ID ); ?></td>
+		</tr>
+		<tr>
 			<th><label for="user-access">Does this person have access to the site?</label></th>
 			<td>
 				<?php $access = get_the_author_meta( self::user_meta, $user->ID ); ?>


### PR DESCRIPTION
Hey! cause the plugin use the registered date to expire a user, it's good to know the registered date already, 'cause this is not actually visible in the profile information
